### PR TITLE
device_id as query parameter and not as body parameter for play_playback

### DIFF
--- a/spotify/http.py
+++ b/spotify/http.py
@@ -1066,6 +1066,7 @@ class HTTPClient:
         """
         route = self.route("PUT", "/me/player/play")
         payload: Dict[str, Any] = {"position_ms": position_ms}
+        params: Dict[str, Any] = {}       
 
         if isinstance(context_uri, str):
             payload["context_uri"] = context_uri
@@ -1108,10 +1109,9 @@ class HTTPClient:
                 )
 
         if device_id is not None:
-            payload["device_id"] = device_id
+            params["device_id"] = device_id
 
-        return self.request(route, json=payload)
-
+        return self.request(route, params=params, json=payload)
     def shuffle_playback(
         self, state: bool, *, device_id: Optional[str] = None
     ) -> Awaitable:


### PR DESCRIPTION
as stated in https://developer.spotify.com/documentation/web-api/reference/player/start-a-users-playback/ the device_id needs to be a query parameter for targeting specific devices