### PR TITLE
Check if device is None before using str(device) as parameter

### DIFF
--- a/spotify/http.py
+++ b/spotify/http.py
@@ -1125,7 +1125,7 @@ class HTTPClient:
         device_id : Optional[:class:`str`]
             The id of the device this command is targeting. If not supplied, the user’s currently active device is the target.
         """
-        route = self.route("PUT", "/me/player/seek")
+        route = self.route("PUT", "/me/player/shuffle")
         payload: Dict[str, Any] = {"state": state}
 
         if device_id is not None:

--- a/spotify/http.py
+++ b/spotify/http.py
@@ -1127,7 +1127,6 @@ class HTTPClient:
         """
         route = self.route("PUT", "/me/player/shuffle")
         payload: Dict[str, Any] = {"state": state}
-
         if device_id is not None:
             payload["device_id"] = device_id
 

--- a/spotify/models/player.py
+++ b/spotify/models/player.py
@@ -81,11 +81,7 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        device_id: Optional[str]
-        if device is not None:
-            device_id = str(device)
-        else:
-            device_id = None
+        device_id: Optional[str] = str(device) if device is not None else None
         await self.user.http.pause_playback(device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
@@ -98,11 +94,7 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        device_id: Optional[str]
-        if device is not None:
-            device_id = str(device)
-        else:
-            device_id = None
+        device_id: Optional[str] = str(device) if device is not None else None
         await self.user.http.play_playback(None, device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
@@ -119,11 +111,7 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        device_id: Optional[str]
-        if device is not None:
-            device_id = str(device)
-        else:
-            device_id = None
+        device_id: Optional[str] = str(device) if device is not None else None
         await self.user.http.seek_playback(pos, device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
@@ -138,11 +126,7 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        device_id: Optional[str]
-        if device is not None:
-            device_id = str(device)
-        else:
-            device_id = None
+        device_id: Optional[str] = str(device) if device is not None else None
         await self.user.http.repeat_playback(state, device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
@@ -157,11 +141,7 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        device_id: Optional[str]
-        if device is not None:
-            device_id = str(device)
-        else:
-            device_id = None
+        device_id: Optional[str] = str(device) if device is not None else None
         await self.user.http.set_playback_volume(volume, device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
@@ -174,11 +154,7 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        device_id: Optional[str]
-        if device is not None:
-            device_id = str(device)
-        else:
-            device_id = None
+        device_id: Optional[str] = str(device) if device is not None else None
         await self.user.http.skip_next(device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
@@ -194,11 +170,7 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        device_id: Optional[str]
-        if device is not None:
-            device_id = str(device)
-        else:
-            device_id = None
+        device_id: Optional[str] = str(device) if device is not None else None
         return await self.user.http.skip_previous(device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
@@ -268,12 +240,7 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        device_id: Optional[str]
-        if device is not None:
-            device_id = str(device)
-        else:
-            device_id = None
-
+        device_id: Optional[str] = str(device) if device is not None else None
         await self.user.http.shuffle_playback(state, device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
@@ -288,9 +255,5 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             if `True` ensure playback happens on new device.
             else keep the current playback state.
         """
-        device_id: Optional[str]
-        if device is not None:
-            device_id = str(device)
-        else:
-            device_id = None
+        device_id: Optional[str] = str(device) if device is not None else None
         await self.user.http.transfer_player(device_id=device_id, play=ensure_playback)

--- a/spotify/models/player.py
+++ b/spotify/models/player.py
@@ -81,7 +81,12 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        await self.user.http.pause_playback(device_id=str(device))
+        device_id: Optional[str]
+        if device is not None:
+            device_id = str(device)
+        else:
+            device_id = None
+        await self.user.http.pause_playback(device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
     async def resume(self, *, device: Optional[SomeDevice] = None):
@@ -93,7 +98,12 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        await self.user.http.play_playback(None, device_id=str(device))
+        device_id: Optional[str]
+        if device is not None:
+            device_id = str(device)
+        else:
+            device_id = None
+        await self.user.http.play_playback(None, device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
     async def seek(self, pos, *, device: Optional[SomeDevice] = None):
@@ -109,7 +119,12 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        await self.user.http.seek_playback(pos, device_id=str(device))
+        device_id: Optional[str]
+        if device is not None:
+            device_id = str(device)
+        else:
+            device_id = None
+        await self.user.http.seek_playback(pos, device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
     async def set_repeat(self, state, *, device: Optional[SomeDevice] = None):
@@ -123,7 +138,12 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        await self.user.http.repeat_playback(state, device_id=str(device))
+        device_id: Optional[str]
+        if device is not None:
+            device_id = str(device)
+        else:
+            device_id = None
+        await self.user.http.repeat_playback(state, device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
     async def set_volume(self, volume: int, *, device: Optional[SomeDevice] = None):
@@ -137,7 +157,12 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        await self.user.http.set_playback_volume(volume, device_id=str(device))
+        device_id: Optional[str]
+        if device is not None:
+            device_id = str(device)
+        else:
+            device_id = None
+        await self.user.http.set_playback_volume(volume, device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
     async def next(self, *, device: Optional[SomeDevice] = None):
@@ -149,7 +174,12 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        await self.user.http.skip_next(device_id=str(device))
+        device_id: Optional[str]
+        if device is not None:
+            device_id = str(device)
+        else:
+            device_id = None
+        await self.user.http.skip_next(device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
     async def previous(self, *, device: Optional[SomeDevice] = None):
@@ -164,7 +194,12 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        return await self.user.http.skip_previous(device_id=str(device))
+        device_id: Optional[str]
+        if device is not None:
+            device_id = str(device)
+        else:
+            device_id = None
+        return await self.user.http.skip_previous(device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
     async def play(
@@ -233,7 +268,13 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             The Device object or id of the device this command is targeting.
             If not supplied, the user’s currently active device is the target.
         """
-        await self.user.http.shuffle_playback(state, device_id=str(device))
+        device_id: Optional[str]
+        if device is not None:
+            device_id = str(device)
+        else:
+            device_id = None
+
+        await self.user.http.shuffle_playback(state, device_id=device_id)
 
     @set_required_scopes("user-modify-playback-state")
     async def transfer(self, device: SomeDevice, ensure_playback: bool = False):
@@ -247,4 +288,9 @@ class Player(SpotifyBase):  # pylint: disable=too-many-instance-attributes
             if `True` ensure playback happens on new device.
             else keep the current playback state.
         """
-        await self.user.http.transfer_player(str(device), play=ensure_playback)
+        device_id: Optional[str]
+        if device is not None:
+            device_id = str(device)
+        else:
+            device_id = None
+        await self.user.http.transfer_player(device_id=device_id, play=ensure_playback)


### PR DESCRIPTION
Added a check because otherwise the requests had the query parameter "device_id=None" (e.g. https://api.spotify.com/v1/me/player/shuffle?state=True&device_id=None)  which was creating a 404 on the spotify api. This happened because when only using str(device) it returns None as a string and that results in failing if checks later in the http.py

To test the changes:
player.next() 
was not working before when no device were specified as a parameter. now it does.