### PR TITLE
fixed flask example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ APP.config.from_mapping({'spotify_client': SPOTIFY_CLIENT})
 REDIRECT_URI: str = 'http://localhost:8888/spotify/callback'
 
 OAUTH2_SCOPES: Tuple[str] = ('user-modify-playback-state', 'user-read-currently-playing', 'user-read-playback-state')
-OAUTH2: spotify.OAuth2 = spotify.OAuth2(SPOTIFY_CLIENT.id, REDIRECT_URI, scope=OAUTH2_SCOPES)
+OAUTH2: spotify.OAuth2 = spotify.OAuth2(SPOTIFY_CLIENT.id, REDIRECT_URI, scopes=OAUTH2_SCOPES)
 
 SPOTIFY_USERS: Dict[str, spotify.User] = {}
 
@@ -120,7 +120,7 @@ def spotify_callback():
 
     return flask.redirect('/')
 
-@APP.route('spotify/failed')
+@APP.route('/spotify/failed')
 def spotify_failed():
     flask.session.pop('spotify_user_id', None)
     return 'Failed to authenticate with Spotify.'

--- a/examples/flask.py
+++ b/examples/flask.py
@@ -13,7 +13,7 @@ APP.config.from_mapping({'spotify_client': SPOTIFY_CLIENT})
 REDIRECT_URI: str = 'http://localhost:8888/spotify/callback'
 
 OAUTH2_SCOPES: Tuple[str] = ('user-modify-playback-state', 'user-read-currently-playing', 'user-read-playback-state')
-OAUTH2: spotify.OAuth2 = spotify.OAuth2(SPOTIFY_CLIENT.id, REDIRECT_URI, scope=OAUTH2_SCOPES)
+OAUTH2: spotify.OAuth2 = spotify.OAuth2(SPOTIFY_CLIENT.id, REDIRECT_URI, scopes=OAUTH2_SCOPES)
 
 SPOTIFY_USERS: Dict[str, spotify.User] = {}
 
@@ -37,7 +37,7 @@ def spotify_callback():
 
     return flask.redirect('/')
 
-@APP.route('spotify/failed')
+@APP.route('/spotify/failed')
 def spotify_failed():
     flask.session.pop('spotify_user_id', None)
     return 'Failed to authenticate with Spotify.'


### PR DESCRIPTION
fixed the two following errors when running the flask example:
```
TypeError: __init__() got an unexpected keyword argument 'scope'
```
and 
```
ValueError: urls must start with a leading slash
```