### PR TITLE
Refresh the token when a request fails - v0.8.2

### DIFF
--- a/spotify/http.py
+++ b/spotify/http.py
@@ -166,17 +166,20 @@ class HTTPClient:
 
         method, url, = route
 
-        if self.bearer_info is None:
-            self.bearer_info = bearer_info = await self.get_bearer_info()
-            access_token = bearer_info["access_token"]
-        else:
-            access_token = self.bearer_info["access_token"]
+        headers = kwargs.pop("headers", {})
+        if "Authorization" not in headers:
+            if self.bearer_info is None:
+                self.bearer_info = bearer_info = await self.get_bearer_info()
+                access_token = bearer_info["access_token"]
+            else:
+                access_token = self.bearer_info["access_token"]
+
+            headers["Authorization"] = "Bearer " + access_token
 
         headers = {
-            "Authorization": "Bearer " + access_token,
             "Content-Type": kwargs.pop("content_type", "application/json"),
             "User-Agent": self.user_agent,
-            **kwargs.pop("headers", {}),
+            **headers,
         }
 
         if "json" in kwargs:
@@ -1702,13 +1705,28 @@ class HTTPClient:
         return self.request(route, params=payload)
 
 
+REFRESH_TOKEN_URL = "https://accounts.spotify.com/api/token?grant_type=refresh_token&refresh_token={refresh_token}"
+
+
 class HTTPUserClient(HTTPClient):
     """HTTPClient for access to user endpoints."""
 
-    def __init__(self, token, loop=None):
-        super().__init__(client_id=None, client_secret=None, loop=loop)
-        self.bearer_info = {"access_token": token}
-        self.token = token
+    def __init__(self, client_id: str, client_secret: str, token: str = None, refresh_token: str = None, loop=None):
+        assert token or refresh_token
+        super().__init__(client_id, client_secret, loop=loop)
+        if token:
+            self.bearer_info = {"access_token": token}
+        self.refresh_token = refresh_token
 
     async def get_bearer_info(self, *_, **__):
-        return {"access_token": self.token}
+        if not self.refresh_token:
+            # Should only happen if User.from_token didn't receive refresh_token
+            raise SpotifyException("Access token expired and no refresh token was provided")
+
+        headers = {
+            "Authorization": f"Basic {b64encode(':'.join((self.client_id, self.client_secret)).encode()).decode()}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        route = ("POST", REFRESH_TOKEN_URL.format(refresh_token=self.refresh_token))
+        return await self.request(route, headers=headers)

--- a/spotify/http.py
+++ b/spotify/http.py
@@ -78,7 +78,7 @@ class HTTPClient:
         self.client_id = client_id
         self.client_secret = client_secret
 
-        self.bearer_info = None
+        self.bearer_info: Optional[Dict[str, str]] = None
 
     @staticmethod
     def route(

--- a/spotify/models/library.py
+++ b/spotify/models/library.py
@@ -186,4 +186,4 @@ class Library(SpotifyBase):
             A sequence of track objects or spotify IDs
         """
         _tracks = [(obj if isinstance(obj, str) else obj.id) for obj in tracks]
-        await self.user.http.save_tracks(",".join(_tracks))
+        await self.user.http.save_tracks(_tracks)

--- a/spotify/models/user.py
+++ b/spotify/models/user.py
@@ -63,7 +63,6 @@ class User(URIBase, AsyncIterable):  # pylint: disable=too-many-instance-attribu
     """
 
     def __init__(self, client: "spotify.Client", data: dict, **kwargs):
-        self.refresh_token = kwargs.pop("refresh_token", None)
         self.__client = self.client = client
 
         if "http" not in kwargs:
@@ -181,7 +180,7 @@ class User(URIBase, AsyncIterable):  # pylint: disable=too-many-instance-attribu
         token : :class:`str`
             The access token to use for http requests.
         refresh_token : :class:`str`
-            Used to acquire new token when token expires.
+            Used to acquire new token when it expires.
         """
         client_id = client.http.client_id
         client_secret = client.http.client_secret
@@ -202,8 +201,7 @@ class User(URIBase, AsyncIterable):  # pylint: disable=too-many-instance-attribu
         client : :class:`spotify.Client`
             The spotify client to associate the user with.
         refresh_token: str
-            Refresh token to be used for retrieval of the initial
-            access token.
+            Used to acquire token.
         """
         return await cls.from_token(client, None, refresh_token)
 

--- a/spotify/models/user.py
+++ b/spotify/models/user.py
@@ -169,8 +169,8 @@ class User(URIBase, AsyncIterable):  # pylint: disable=too-many-instance-attribu
     async def from_token(
         cls,
         client: "spotify.Client",
-        token: str = None,
-        refresh_token: str = None,
+        token: Optional[str],
+        refresh_token: Optional[str] = None,
     ):
         """Create a :class:`User` object from an access token.
 


### PR DESCRIPTION
I rebased the changes from Pull Request #40 onto v0.8.2.

I also snuck in a fix to the user.library.save_tracks function.