### PR TITLE
Fix for scopes and flask example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ def spotify_callback():
         SPOTIFY_USERS[key] = spotify.User.from_code(
             SPOTIFY_CLIENT,
             code,
-            redirect_uri=REDIRECT_URI,
-            refresh=True
+            redirect_uri=REDIRECT_URI
         )
 
         flask.session['spotify_user_id'] = key

--- a/examples/flask.py
+++ b/examples/flask.py
@@ -29,8 +29,7 @@ def spotify_callback():
         SPOTIFY_USERS[key] = spotify.User.from_code(
             SPOTIFY_CLIENT,
             code,
-            redirect_uri=REDIRECT_URI,
-            refresh=True
+            redirect_uri=REDIRECT_URI
         )
 
         flask.session['spotify_user_id'] = key

--- a/spotify/oauth.py
+++ b/spotify/oauth.py
@@ -197,6 +197,6 @@ class OAuth2:
         for scope_name, state in scopes.items():
             scope_name = scope_name.replace("_","-")
             if state:
-                self.__scopes.add(scope_name))
+                self.__scopes.add(scope_name)
             else:
                 self.__scopes.remove(scope_name)

--- a/spotify/oauth.py
+++ b/spotify/oauth.py
@@ -185,8 +185,9 @@ class OAuth2:
         r"""Modify the scopes for the current oauth2 object.
 
         Add or remove certain scopes from this oauth2 instance.
+        Since hypens are not allowed, replace the _ with -.
 
-        >>> oauth2.set_scopes(user_read_playback_state=True, user-modify-playback-state=False)
+        >>> oauth2.set_scopes(user_read_playback_state=True)
 
         Parameters
         ----------
@@ -194,7 +195,8 @@ class OAuth2:
             The scopes to enable or disable.
         """
         for scope_name, state in scopes.items():
+            scope_name = scope_name.replace("_","-")
             if state:
-                self.__scopes.add(scope_name)
+                self.__scopes.add(scope_name))
             else:
                 self.__scopes.remove(scope_name)


### PR DESCRIPTION
- Fix - in scopes. The permissions actually use - instead of _. Additionally - are not allowed in kwargs. Hence replace the -, with _ after the user has provided it to match the appropriate scopes.
- Remove refresh keyword for from code as it is not part of the arguments for the method.