### PR TITLE
User: Add token getters

### DIFF
--- a/examples/user/user_auth.py
+++ b/examples/user/user_auth.py
@@ -31,7 +31,10 @@ async def main():
 
     # REFRESHING: enabling a refreshing session is controlled through a kwarg `refresh` that takes a `bool`
 
-    User.from_code(client, 'somecode', redirect_uri='some://redirect', refresh=False)
+    authed_user = await User.from_code(client, 'somecode', redirect_uri='some://redirect', refresh=False)
+
+    # Get refresh token, to use in future to authenticate User.from_token
+    ref_token = authed_user.get_refresh_token()
 
     ## User.from_token
 

--- a/spotify/models/user.py
+++ b/spotify/models/user.py
@@ -198,6 +198,8 @@ class User(URIBase, AsyncIterable):  # pylint: disable=too-many-instance-attribu
         refresh_token : :class:`str`
             Used to acquire new token when it expires.
         """
+        cls.token = token
+        cls.refresh_token = refresh_token
         client_id = client.http.client_id
         client_secret = client.http.client_secret
         http = HTTPUserClient(client_id, client_secret, token, refresh_token)
@@ -220,6 +222,12 @@ class User(URIBase, AsyncIterable):  # pylint: disable=too-many-instance-attribu
         return await cls.from_token(client, None, refresh_token)
 
     ### Contextual methods
+
+    def get_token(self):
+        return self.token
+
+    def get_refresh_token(self):
+        return self.refresh_token
 
     @ensure_http
     async def currently_playing(self) -> Dict[str, Union[Track, Context, str]]:


### PR DESCRIPTION
When I started using `spotify.py` module for my hobby project, I ran into a problem:
First time, I authenticate from code -> Spotify gives me a token;
For all future times, I authenticate from that token.
The problem is: API doesn't let me get the token after my first authentication.
This commit solves it.

I might miss the coding style, comments, documentation, or test coverage.
It is also possible, that you would prefer to access `token` and `refresh_token` as attributes, instead of via getters.
If so - please let me know, how I could improve the commit, to satisfy `spotify.py` quality standard.

---

Use-case:

* First time user authenticates - authenticate from code
* Get token or refresh_token, given by Spotify
* Save token into a file
* For future user authentications - authenticate from token

This way, spotify.py module allows scripts to "remember" user, after he
authenticated once.